### PR TITLE
Settings page bug fix

### DIFF
--- a/address-geocoder.php
+++ b/address-geocoder.php
@@ -33,6 +33,11 @@ class Address_Geocoder
         $excluded = array( 'attachment', 'revision', 'nav_menu_item' );
         $this->available_post_types = array_diff( $post_types, $excluded );
         $this->options = get_option( 'address_geocoder_options' );
+        
+        // Set some default options if none are already set
+        if( !$this->options ) {
+            $this->options = $this->available_post_types;
+        }
 
         // Actions
         add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );


### PR DESCRIPTION
Fixes a bug on the settings page where no post types would be displayed
under 'Show Metabox on Post Types'.

The bug occurs when a user first installs the plugin. This is because the option `address_geocoder_options` is yet to be created in the database which causes an error to be thrown when we try to loop though the results of `get_option( 'address_geocoder_options' )`.
