### PR TITLE
Draggable map marker!

### DIFF
--- a/address-geocoder.js
+++ b/address-geocoder.js
@@ -2,15 +2,17 @@
 
     $(function() {
 
-        var map;
-        var latlng;
-        var markersArray = [];
+        var map,
+            latlng,
+            marker,
+            markersArray = [];
 
         setMarker = function(latlng) {
             clearMarkers();
-            var marker = new google.maps.Marker({
+            marker = new google.maps.Marker({
                 map: map,
-                position: latlng
+                position: latlng,
+                draggable: true
             });
             markersArray.push(marker);
         }
@@ -24,6 +26,10 @@
 
         // Trigger geocode
         $(document).on('click', '#geocode', function() {
+            if ($('#martygeocoderlatlng').val() ) {
+                return;
+            }
+            
             var address = $('#martygeocoderaddress').val();
             var geocoder = new google.maps.Geocoder();
 
@@ -47,12 +53,21 @@
         latlng = new google.maps.LatLng(latlng[0], latlng[1]);
 
         map = new google.maps.Map(document.getElementById('geocodepreview'), {
+            zoomcontrol: true,
             mapTypeControl: false,
+            streetViewControl: false,
             zoom: 11,
             center: latlng,
             mapTypeId: google.maps.MapTypeId.ROADMAP
         });
         setMarker(latlng);
+
+        //Update Lat/Lng if marker is dragged to new position.
+        google.maps.event.addListener(marker, 'dragend', function (event) {
+            latlng = this.getPosition();
+            $('#martygeocoderlatlng').attr('value', latlng);
+            map.setCenter(latlng);
+        });
     });
 
 })(jQuery);

--- a/address-geocoder.php
+++ b/address-geocoder.php
@@ -68,7 +68,7 @@ class Address_Geocoder
             $apikey = $address_geocoder_options['apikey'];
 
             if ( ! empty( $apikey ) ) {
-                $mapsapi = '//maps.googleapis.com/maps/api/js?key=' . $apikey. '&sensor=false';
+                $mapsapi = '//maps.googleapis.com/maps/api/js?key=' . $apikey;
                 wp_register_script( 'googlemaps', $mapsapi );
                 wp_register_script( 'marty_geocode_js', plugins_url( '/address-geocoder.js', __FILE__ ) );
 
@@ -122,7 +122,7 @@ class Address_Geocoder
         $apikey = $address_geocoder_options['apikey'];
         if ( $apikey && $apikey != '' ): ?>
             <div style="overflow:hidden; width:100%">
-                <div id="geocodepreview" style="float:right; width:240px; height:180px; border:1px solid #DFDFDF"></div>
+                <div id="geocodepreview" style="float:right; width:240px; height:240px; border:1px solid #DFDFDF"></div>
                 <div style="margin-right:260px">
                     <p>
                         <label for="martygeocoderaddress">Address</label><br />


### PR DESCRIPTION
This PR adds support for a draggable map marker. It also updates the Lat/Lng text field.

This is useful should an address no quite geocode correctly or if one would like to slightly adjust the marker of a geocoded address.